### PR TITLE
fix: A2DP defaulting to low quality

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bluez (5.64-0ubuntu1pop1) jammy; urgency=medium
+
+  * https://git.launchpad.net/~bluetooth/bluez/plain/debian/patches/a2dp-Always-invalidate-the-cache-if-its-configuratio.patch?h=jammy&id=ec33a54311f9948497438bd754ec2a03b9739f21
+
+ -- Michael Murphy <michael@mmurphy.dev>  Fri, 20 Jan 2023 15:14:41 +0100
+
 bluez (5.64-0ubuntu1pop0) jammy; urgency=medium
 
   * Pop!_OS patches

--- a/debian/patches/a2dp-fix-defaulting-to-low-quality.patch
+++ b/debian/patches/a2dp-fix-defaulting-to-low-quality.patch
@@ -1,0 +1,28 @@
+Description: a2dp: Always invalidate the cache if its configuration fails
+Origin: Upstream commit 62e591578e3f948e187aacf44ede4286fad37ad7 (in v5.65)
+Bug: https://github.com/bluez/bluez/issues/313
+Bug-Ubuntu: https://launchpad.net/bugs/1988364
+Last-Update: 2023-01-16
+
+diff --git a/profiles/audio/a2dp.c b/profiles/audio/a2dp.c
+index d66c22b2b..c3ac432a7 100644
+--- a/profiles/audio/a2dp.c
++++ b/profiles/audio/a2dp.c
+@@ -872,12 +872,10 @@ static void store_remote_seps(struct a2dp_channel *chan)
+ static void invalidate_remote_cache(struct a2dp_setup *setup,
+ 						struct avdtp_error *err)
+ {
+-	if (err->category == AVDTP_ERRNO ||
+-			err->err.error_code != AVDTP_UNSUPPORTED_CONFIGURATION)
++	if (err->category == AVDTP_ERRNO)
+ 		return;
+ 
+-	/* Attempt to unregister Remote SEP if configuration
+-	 * fails with Unsupported Configuration and it was
++	/* Attempt to unregister Remote SEP if configuration fails and it was
+ 	 * loaded from cache.
+ 	 */
+ 	if (setup->rsep && setup->rsep->from_cache) {
+-- 
+2.38.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -14,5 +14,7 @@ raspi-bcm43xx-load-firmware.patch
 raspi-bcm43xx-3wire.patch
 raspi-cypress-305-bdaddr.patch
 
+a2dp-fix-defaulting-to-low-quality.patch
+
 # Pop!_OS patches
 fix-suspend.patch


### PR DESCRIPTION
Pulled from Ubuntu. This patch was backported to Jammy 4 days ago.

https://git.launchpad.net/~bluetooth/bluez/commit/?h=jammy&id=ec33a54311f9948497438bd754ec2a03b9739f21